### PR TITLE
Refactored NFT Methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,12 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@metaplex-foundation/js": "^0.20.1",
+    "@metaplex-foundation/digital-asset-standard-api": "^1.0.4",
+    "@metaplex-foundation/mpl-token-metadata": "^3.3.0",
+    "@metaplex-foundation/umi": "^1.0.0",
+    "@metaplex-foundation/umi-bundle-defaults": "^1.0.0",
     "@solana/spl-token": "^0.4.9",
-    "@solana/web3.js": "^1.95.8",
+    "@solana/web3.js": "^1.98.0",
     "bip39": "^3.1.0",
     "bs58": "^6.0.0",
     "dotenv": "^16.4.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,8 +258,8 @@ export default class SolanaLib {
   }
 
   public async getNftCountByAddressAndCollection(
-      ownerAddress: string,
       collectionAddress: string,
+      ownerAddress: string = '',
       chainId: string = 'solana:mainnet'
   ): Promise<number> {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,10 @@ import bs58 from 'bs58'
 import nacl from 'tweetnacl'
 import bip39 from 'bip39'
 import { derivePath } from 'ed25519-hd-key'
-import { Metaplex } from '@metaplex-foundation/js'
+import { fetchAllDigitalAssetWithTokenByOwner } from "@metaplex-foundation/mpl-token-metadata";
+import { publicKey } from "@metaplex-foundation/umi";
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults'
+import { mplTokenMetadata } from '@metaplex-foundation/mpl-token-metadata'
 
 export const SOLANA_MAINNET_CHAINS: any = {
   'solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ': {
@@ -219,11 +222,61 @@ export default class SolanaLib {
     return amount
   }
 
-  public async getNfts(chainId: string = 'solana:mainnet'): Promise<any[]> {
-    const connection = this.getConnection(chainId)
-    const metaplex = Metaplex.make(connection)
-    const allNfts = await metaplex.nfts().findAllByOwner({ owner: this.keypair.publicKey })
-    return allNfts as any[]
+  public async getNfts(ownerAddress: string = '', chainId: string = 'solana:mainnet'): Promise<any[]> {
+    try {
+      if (!ownerAddress) {
+        ownerAddress = this.keypair.publicKey;
+      }
+
+      // Get RPC Endpoint
+      const endpoint = this.getConnection(chainId).rpcEndpoint()
+
+      // Create a UMI instance
+      const umi = createUmi(endpoint).use(mplTokenMetadata());
+
+      // The owner's public key
+      const ownerPublicKey = publicKey(ownerAddress);
+
+      const allTokens = await fetchAllDigitalAssetWithTokenByOwner(
+          umi,
+          ownerPublicKey,
+      );
+
+      const allNFTs = [];
+      allTokens.forEach((asset, index) => {
+        if (asset.metadata.collection.__option === "None") {
+          return;
+        }
+
+        allNFTs.push(asset);
+      });
+
+      return allNFTs as any[];
+    } catch (error) {
+      return [] as any[];
+    }
+  }
+
+  public async getNftCountByAddressAndCollection(
+      ownerAddress: string,
+      collectionAddress: string,
+      chainId: string = 'solana:mainnet'
+  ): Promise<number> {
+    try {
+      const nfts = await this.getNfts(ownerAddress, chainId);
+      const collectionNFTs = [];
+      nfts.forEach((nft, index) => {
+        if (nft.metadata.collection.value.key !== collectionAddress) {
+          return;
+        }
+
+        collectionNFTs.push(nft);
+      });
+
+      return collectionNFTs.length;
+    } catch (error) {
+      return 0;
+    }
   }
 
   public async sendSol(to: string, amountSol: number, chainId: string = 'solana:mainnet'): Promise<any> {
@@ -393,3 +446,4 @@ export default class SolanaLib {
     return incoming
   }
 }
+


### PR DESCRIPTION
I refactored the `getNfts` method to use a different method for retrieving NFTs for a given address.

I also added a new method, `getNftCountByAddressAndCollection` which can be used to retrieve the count of NFTs for a given owning address from a given collection address to easily get the amount of NFTs from a given collection that an address owns.